### PR TITLE
[Add]管理者ログイン画面

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'kaminari'
 gem 'image_processing'
+gem 'acts-as-taggable-on', '~> 7.0'
+gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts-as-taggable-on (7.0.0)
+      activerecord (>= 5.0, < 6.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     bcrypt (3.1.17)
@@ -86,6 +88,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -123,10 +129,12 @@ GEM
     method_source (1.0.0)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.4.5)
     nio4r (2.5.8)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     public_suffix (4.0.6)
@@ -233,13 +241,15 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 7.0)
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
   devise
+  dotenv-rails
   image_processing
   jbuilder (~> 2.7)
   kaminari
@@ -261,4 +271,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.3.8
+   1.17.3

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -18,10 +18,18 @@ class Admin::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+   def after_sign_in_path_for(resource)
+     admin_orders_path
+   end
+
+   def after_sign_out_path_for(resource)
+     new_admin_session_path
+   end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,7 +1,7 @@
 class Admin < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
   validates :encrypted_password, length: { minimum: 6, maximum: 15 }
 end

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,2 +1,5 @@
 <h1>Admin::Orders#index</h1>
 <p>Find me in app/views/admin/orders/index.html.erb</p>
+<li>
+  <%= link_to "ログアウト", destroy_admin_session_path, method: :delete %>
+</li>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,25 +1,18 @@
-<h2>Log in</h2>
+<h2>管理者ログイン</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email, "メールアドレス" %>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :password, "パスワード" %>
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログイン" %>
   </div>
 <% end %>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,18 +89,18 @@ ActiveRecord::Schema.define(version: 2022_03_16_080322) do
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
   end
 
-  create_table "genres", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "items", force: :cascade do |t|
     t.integer "genre_id"
     t.string "name"
     t.text "description"
     t.boolean "item_status"
     t.integer "price"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "jenres", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Admin.create(
+    email: ENV['ADMIN_MAIL'],
+    password: ENV['ADMIN_PASS']
+)


### PR DESCRIPTION


## 概要

- 管理者用メールアドレスとパ スワードを事前にデータベースへ登録します。

## 変更内容

- Gemfile
    - `gem 'dotenv-rails'`を追加。環境変数を使用します。
- .envファイルの作成
    - `ADMIN_MAIL`と`ADMIN_PASS`を定義しメールアドレスとパスワードを環境変数に設定します。
-  seeds.rb
    - `Admin.create()`で管理者ユーザーを作成。
- .gitignore
    - `/.env`を記述しGit管理下から除外する。
- sessions_controller.rb
    - ログイン後は注文一覧画面に、ログアウト後はログイン画面に遷移する。

